### PR TITLE
Fix 11on12 Adapter leak

### DIFF
--- a/src/adapter.cpp
+++ b/src/adapter.cpp
@@ -101,7 +101,7 @@ namespace D3D11On12
     HRESULT APIENTRY Adapter::CloseAdapter(_In_ D3D10DDI_HADAPTER hAdapter)
     {
         auto pAdapter = CastFrom(hAdapter);
-        pAdapter->~Adapter();
+        delete pAdapter;
         return S_OK;
     }
 


### PR DESCRIPTION
Adapter was created with allocating new, but was using placement delete.  Fixed deletion.