### PR TITLE
Refactor Underlying Video Device Creation

### DIFF
--- a/include/VideoDevice.hpp
+++ b/include/VideoDevice.hpp
@@ -56,17 +56,20 @@ namespace D3D11On12
 
         // End Video DDI entry points
 #endif
-        virtual D3D12TranslationLayer::VideoDevice* UnderlyingVideoDevice()
+        D3D12TranslationLayer::VideoDevice* UnderlyingVideoDevice()
         {
-            return &m_UnderlyingVideoDevice;
+            return m_UnderlyingVideoDevice.get();
         }
+
+        virtual void Initialize();
+
+    protected:
+        std::unique_ptr<D3D12TranslationLayer::VideoDevice> m_UnderlyingVideoDevice;
 
     private:
         static bool CheckHardwareDRMSupport(_In_ Device *pDevice, _In_ const GUID* pCryptoType, _In_ const GUID* pDecodeProfile);
         static void GetContentProtectionSystems(_In_ Device *pDevice, _In_ const GUID *pCryptoType, std::vector<GUID> &contentProtectionSystems);
         static void GetDecodeProfiles(_In_ Device *pDevice, _In_ const GUID *pDecodeProfile, std::vector<GUID> &decodeProfiles);
-
-        D3D12TranslationLayer::VideoDevice m_UnderlyingVideoDevice;
     };
 
 };

--- a/src/VideoDevice.cpp
+++ b/src/VideoDevice.cpp
@@ -133,9 +133,13 @@ namespace D3D11On12
     }
 
     VideoDevice::VideoDevice(Device& parent) :
-        DeviceChild(parent),
-        m_UnderlyingVideoDevice(&parent.GetImmediateContextNoFlush())
+        DeviceChild(parent)
     {
+    }
+
+    void VideoDevice::Initialize()
+    {
+        m_UnderlyingVideoDevice = std::make_unique<D3D12TranslationLayer::VideoDevice>(&m_parentDevice.GetImmediateContextNoFlush());
     }
 
     void APIENTRY VideoDevice::GetVideoDecoderProfileCount(_In_ D3D10DDI_HDEVICE hDevice, _Out_ UINT *pProfileCount)

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -149,6 +149,7 @@ namespace D3D11On12
         if (!m_pVideoDevice)
         {
             m_pVideoDevice.reset(new VideoDevice(*this));
+            m_pVideoDevice->Initialize();
         }
 
         return S_OK;


### PR DESCRIPTION
-  Convert the underlying video device to a unique_ptr for easier extensibility
-  Move underlying video device creation to a separate initialize call