### PR TITLE
Memory Leak fixes in VideoDevice and VideoProcess

### DIFF
--- a/include/VideoProcess.hpp
+++ b/include/VideoProcess.hpp
@@ -55,6 +55,8 @@ namespace D3D11On12
 
     protected:
         VideoProcess(Device& parent, UINT MaxInputStreams, bool AutoProcessingSupported);
+        virtual ~VideoProcess() {}
+
         virtual void ProcessFrames(UINT streamCount) { UnderlyingVideoProcess()->ProcessFrames(&m_inputArguments, streamCount, &m_outputArguments); }
 
         std::unique_ptr<D3D12TranslationLayer::BatchedVideoProcess> m_UnderlyingVideoProcess;

--- a/include/device.hpp
+++ b/include/device.hpp
@@ -455,7 +455,7 @@ namespace D3D11On12
 
         const D3D12TranslationLayer::ResourceAllocationContext m_ResourceAllocationContext;
 
-        AutoCleanupPtr<VideoDevice> m_pVideoDevice;
+        std::unique_ptr<VideoDevice> m_pVideoDevice;
 
         struct PresentExtensionData
         {


### PR DESCRIPTION
- Convert VideoDevice to a unique_ptr since AutoCleanupPtr does not call delete
- Add a virtual destructor to VideoProcess to prevent leaks in derived classes