### PR TITLE
SetNeedsSubmitFence for external waits

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -1167,6 +1167,7 @@ namespace D3D11On12
                 {
                     auto* pFence = pCommandListManager->GetFence();
                     pCommmandQueue->Wait(pFence->Get(), WaitValue);
+                    pCommandListManager->SetNeedSubmitFence();
                 }
             }
         }


### PR DESCRIPTION
SetNeedsSubmitFence when adding waits to external queue to prevent deadlocks with UnwrapUnderlyingResource.