### PR TITLE
EnsureVideoDevice to catch _comerror exceptions from d3d12translationlayer construction/initialization and wrap them as HR Code return value for caller.

### DIFF
--- a/include/device.hpp
+++ b/include/device.hpp
@@ -420,7 +420,7 @@ namespace D3D11On12
         /* End DDI Entry points*/
 
         VideoDevice *GetVideoDevice();
-        virtual HRESULT EnsureVideoDevice();
+        virtual void EnsureVideoDevice();
 
         D3D12TranslationLayer::ResourceAllocationContext GetResourceAllocationContext() const noexcept { return m_ResourceAllocationContext; }
         D3D10DDI_HRTDEVICE GetRTDeviceHandle() const { return m_hRTDevice; }

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -146,10 +146,20 @@ namespace D3D11On12
     //----------------------------------------------------------------------------------------------------------------------------------
     HRESULT Device::EnsureVideoDevice()
     {
-        if (!m_pVideoDevice)
+        try
         {
-            m_pVideoDevice.reset(new VideoDevice(*this));
-            m_pVideoDevice->Initialize();
+            if (!m_pVideoDevice)
+            {
+                m_pVideoDevice.reset(new VideoDevice(*this));
+                m_pVideoDevice->Initialize();
+            }
+        }
+        catch (_com_error& hrEx)
+        {
+            // If Initialize() failed, we need to cleanup the D3D11On12 object that's badly initialized
+            m_pVideoDevice = nullptr;
+
+            return hrEx.Error();
         }
 
         return S_OK;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -144,7 +144,7 @@ namespace D3D11On12
     }
 
     //----------------------------------------------------------------------------------------------------------------------------------
-    HRESULT Device::EnsureVideoDevice()
+    void Device::EnsureVideoDevice()
     {
         try
         {
@@ -154,15 +154,11 @@ namespace D3D11On12
                 m_pVideoDevice->Initialize();
             }
         }
-        catch (_com_error& hrEx)
+        catch (...)
         {
-            // If Initialize() failed, we need to cleanup the D3D11On12 object that's badly initialized
             m_pVideoDevice = nullptr;
-
-            return hrEx.Error();
+            throw;
         }
-
-        return S_OK;
     }
 
     //----------------------------------------------------------------------------------------------------------------------------------
@@ -196,12 +192,9 @@ namespace D3D11On12
         else
         {
             D3DWDDM2_4DDI_VIDEO_INPUT *pInput = static_cast<D3DWDDM2_4DDI_VIDEO_INPUT *>(pParams);
-            hr = pDevice->EnsureVideoDevice();
-            if (SUCCEEDED(hr))
-            {
-                VideoDevice *pVideoDevice = pDevice->GetVideoDevice();
-                pVideoDevice->FillVideoDDIFunctions(pInput->pWDDM2_4VideoDeviceFuncs);
-            }
+            pDevice->EnsureVideoDevice();
+            VideoDevice *pVideoDevice = pDevice->GetVideoDevice();
+            pVideoDevice->FillVideoDDIFunctions(pInput->pWDDM2_4VideoDeviceFuncs);
         }
         
         D3D11on12_DDI_ENTRYPOINT_END_AND_RETURN_HR(hr);


### PR DESCRIPTION
EnsureVideoDevice to catch _comerror exceptions from d3d12translationlayer construction/initialization and wrap them as HR Code return value for caller. This way, for example QueryInterface for a D3D11VideoDevice using 11on12 will return E_NOINTERFACE.