### PR TITLE
Fix SOpenAdapterArgs struct in DDI

### DIFF
--- a/include/adapter.hpp
+++ b/include/adapter.hpp
@@ -38,6 +38,7 @@ namespace D3D11On12
         bool m_bComputeOnly;
 
         PrivateCallbacks m_Callbacks;
+        PrivateCallbacks2 m_Callbacks2;
         const bool m_bAPIDisablesGPUTimeout;
         const bool m_bSupportDisplayableTextures;
         const bool m_bSupportDeferredContexts;

--- a/interface/D3D11On12DDI.h
+++ b/interface/D3D11On12DDI.h
@@ -70,10 +70,14 @@ struct PrivateCallbacks
 {
     D3D11_RESOURCE_FLAGS (CALLBACK *GetResourceFlags)(_In_ D3D10DDI_HRESOURCE, _Out_ bool *pbAcquireableOnWrite);
     bool (CALLBACK *NotifySharedResourceCreation)(_In_ HANDLE, _In_ IUnknown*);
-    HRESULT(CALLBACK *Present11On12CB)(_In_ HANDLE, _In_ Present11On12CBArgs*);
 };
 
-constexpr UINT c_CurrentD3D11On12InterfaceVersion = 6;
+struct PrivateCallbacks2
+{
+    HRESULT(CALLBACK* Present11On12CB)(_In_ HANDLE, _In_ Present11On12CBArgs*);
+};
+
+constexpr UINT c_CurrentD3D11On12InterfaceVersion = 7;
 
 struct SOpenAdapterArgs
 {
@@ -89,6 +93,8 @@ struct SOpenAdapterArgs
     bool bSupportDeferredContexts;
 
     UINT D3D11On12InterfaceVersion = c_CurrentD3D11On12InterfaceVersion;
+
+    PrivateCallbacks2* Callbacks2;
 };
 
 #define D3D11DDI_CREATEDEVICE_FLAG_IS_XBOX 0x80000000

--- a/src/adapter.cpp
+++ b/src/adapter.cpp
@@ -21,12 +21,13 @@ namespace D3D11On12
         , m_p3DCommandQueue(Args.p3DCommandQueue)
         , m_NodeIndex(Args.NodeIndex)
         , m_Callbacks(Args.Callbacks)
+        , m_Callbacks2(Args.D3D11On12InterfaceVersion >= 7 ? *Args.Callbacks2 : PrivateCallbacks2())
         , m_bAPIDisablesGPUTimeout(Args.bDisableGPUTimeout)
         , m_bSupportDisplayableTextures(Args.D3D11On12InterfaceVersion >= 5 ?
             Args.bSupportDisplayableTextures : false)
         , m_bSupportDeferredContexts(Args.D3D11On12InterfaceVersion >= 5 ?
             Args.bSupportDeferredContexts : true)
-        , m_bSupportsNewPresentPath(Args.D3D11On12InterfaceVersion >=6 ? Args.Callbacks.Present11On12CB != nullptr : false)
+        , m_bSupportsNewPresentPath(Args.D3D11On12InterfaceVersion >=7 ? Args.Callbacks2->Present11On12CB != nullptr : false)
     {
         static const D3D10_2DDI_ADAPTERFUNCS AdapterFuncs = {
             CalcPrivateDeviceSize,

--- a/src/present.cpp
+++ b/src/present.cpp
@@ -249,7 +249,7 @@ namespace D3D11On12
                     cbArgs.pGraphicsCommandQueue = args.pGraphicsCommandQueue;
                     cbArgs.pKMTPresent = args.pKMTPresent;
                     cbArgs.vidPnSourceId = args.vidPnSourceId;
-                    return (*adapter->m_Callbacks.Present11On12CB)(rtDeviceHandle, &cbArgs);
+                    return (*adapter->m_Callbacks2.Present11On12CB)(rtDeviceHandle, &cbArgs);
                 };
 
                 m_d3d12tlPresentSurfaces.clear();


### PR DESCRIPTION
Since the original PrivateCallbacks struct was just embedded in the
middle of the SOpenAdapterArgs struct (not a pointer), adding new fields
breaks compatibility between version, yikes! This commit adds a new
PrivateCallbacks2 struct that is referenced with a pointer at the end of
the SOpenAdapterArgs struct and includes the new present callback to
make things compatible again.