### PR TITLE
[Clang] Fix expected a qualified name after 'typename' warning

### DIFF
--- a/include/view.hpp
+++ b/include/view.hpp
@@ -37,7 +37,7 @@ namespace D3D11On12
             return (pView) ? pView->GetTranslationLayerView() : nullptr;
         }
 
-        static void GatherViewsFromHandles(typename const Traits::ViewHandle* pHViews, typename Traits::TranslationLayerView ** pUnderlying, UINT count)
+        static void GatherViewsFromHandles(const typename Traits::ViewHandle* pHViews, typename Traits::TranslationLayerView ** pUnderlying, UINT count)
         {
             for (size_t i = 0; i < count; i++)
             {


### PR DESCRIPTION
Clang requires typename to appear only before a qualified dependent name (a name containing :: that depends on a template parameter). When typename is used before an unqualified name — such as a typedef alias or a plain template parameter — Clang warns it with:

`warning: expected a qualified name after 'typename'`

MSVC silently accepts redundant typename before unqualified names in all modes, including /permissive- — it has no diagnostic for this pattern. Clang enforces the C++ grammar rule that typename must precede a qualified name (containing :: ), and emits a warning when it doesn't.

**Changes**

1. include/view.hpp: Reordered typename const Traits::ViewHandle* to const typename Traits::ViewHandle*

**Validation**

1. Verified the fix resolves the Clang error in the OS repo build at src\onecoreuap\windows\DirectX\dxg\d3d11\D3D11On12\linkdll.
2. No other instances of this pattern exist in the D3D11On12 repo.