### PR TITLE
Fix -Winvalid-token-paste Clang warnings

### DIFF
--- a/include/view.hpp
+++ b/include/view.hpp
@@ -11,7 +11,7 @@ namespace D3D11On12
 #define DECLARE_VIEW_TRAITS(View, AbbreviatedView, DDIDescType, HandleType) \
     template<> struct ViewTraits<ID3D11##View> \
     { \
-    typedef D3D12TranslationLayer::##AbbreviatedView TranslationLayerView; \
+    typedef D3D12TranslationLayer::AbbreviatedView TranslationLayerView; \
     typedef HandleType ViewHandle; \
     typedef DDIDescType DDIDesc; \
     }


### PR DESCRIPTION
## Summary

Remove a spurious `##` between `::` and the `AbbreviatedView` macro argument in the `ViewTraits` template specialization. The expansion `D3D12TranslationLayer::##AbbreviatedView` joins a punctuator (`::`) to an identifier (`SRV`, `RTV`, …), which forms two tokens (`::` and `SRV`), not one — exactly what clang rejects under `-Winvalid-token-paste`.

Removing the `##` yields the byte-identical token stream the author intended (`D3D12TranslationLayer :: SRV`) and is now standards-conforming. The legitimate paste `ID3D11##View` that builds `ID3D11ShaderResourceView` is preserved.

MSVC's traditional preprocessor silently dropped the broken paste, so the change has no behavioral impact on existing MSVC builds.

## Errors fixed

| File | Error pattern | Count (baseline) |
|---|---|---|
| `include/view.hpp` | `'::SRV'`, `'::RTV'`, `'::DSV'`, `'::UAV'`, `'::VDOV'`, `'::VPIV'`, `'::VPOV'` | 7 (per build target; 42 across all consumers per the original CSV) |

## Validation

Local build.