### PR TITLE
ci(prBuild): target 26100 SDK, and install the 26100 WDK

### DIFF
--- a/.github/workflows/prBuild.yml
+++ b/.github/workflows/prBuild.yml
@@ -23,10 +23,25 @@ jobs:
       with:
         nuget-version: latest
 
+    - name: Install Windows Driver Kit
+      shell: pwsh
+      run: |
+        winget install --id Microsoft.WindowsWDK.10.0.26100 `
+          --silent --accept-package-agreements --accept-source-agreements `
+          --disable-interactivity --custom "/features +"
+        $includeRoot     = "${env:ProgramFiles(x86)}\Windows Kits\10\Include\10.0.26100.0\um"
+        $requiredHeaders = @('d3d12TokenizedProgramFormat.hpp', 'd3d10umddi.h')
+        foreach ($header in $requiredHeaders) {
+          $path = Join-Path $includeRoot $header
+          if (-not (Test-Path $path)) {
+            throw "WDK install did not place $path (try /features + ?)"
+          }
+        }
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_SYSTEM_VERSION="10.0.22621.0"
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_SYSTEM_VERSION="10.0.26100.0"
 
     - name: Nuget Restore
       run: nuget restore ${{github.workspace}}/build/D3D11on12.sln


### PR DESCRIPTION
PR build was failing because windows-latest runners ship Windows SDKs (10.0.22621.0 and 10.0.26100.0) but no WDK. D3D12TranslationLayer's DxbcParser transitively includes d3d12TokenizedProgramFormat.hpp, which only ships with the WDK.

Install the WDK matching CMAKE_SYSTEM_VERSION (10.0.22621.0) via winget (pre-installed on windows-latest). The 22621 WDK places its headers under the same Windows Kits\10\Include\10.0.22621.0 path the SDK uses, so CL picks them up with no extra include paths.

The verification step asserts the expected header lands at the expected path, so a future winget package-id rename trips a clear failure instead of an opaque C1083.