### PR TITLE
Fix clang errors blocking PCH compile and remaining Clang errors

### DIFF
--- a/include/DeviceChild.hpp
+++ b/include/DeviceChild.hpp
@@ -47,10 +47,10 @@ namespace D3D11On12
         destroy = InitializeDeferredHandle<TFunc>::Destroy;
     }
 
-    template <typename... TArgs>
-    struct InitializeDeferredHandle<void (APIENTRY*)(D3D10DDI_HDEVICE, const UINT*, D3D10DDI_HSHADER, D3D10DDI_HRTSHADER, TArgs...)>
+    template <typename TSignature, typename... TArgs>
+    struct InitializeDeferredHandle<void (APIENTRY*)(D3D10DDI_HDEVICE, const UINT*, D3D10DDI_HSHADER, D3D10DDI_HRTSHADER, TSignature, TArgs...)>
     {
-        static void Initialize(D3D10DDI_HDEVICE, const UINT*, D3D10DDI_HSHADER handle, D3D10DDI_HRTSHADER rtHandle, TArgs...)
+        static void Initialize(D3D10DDI_HDEVICE, const UINT*, D3D10DDI_HSHADER handle, D3D10DDI_HRTSHADER rtHandle, TSignature, TArgs...)
         {
             reinterpret_cast<DeviceChildDeferred<D3D10DDI_HSHADER>*>(handle.pDrvPrivate)->m_ImmediateHandle = D3D10DDI_HSHADER{ rtHandle.handle };
         }

--- a/include/DeviceChild.hpp
+++ b/include/DeviceChild.hpp
@@ -47,10 +47,10 @@ namespace D3D11On12
         destroy = InitializeDeferredHandle<TFunc>::Destroy;
     }
 
-    template <typename... TArgs>
-    struct InitializeDeferredHandle<void (APIENTRY*)(D3D10DDI_HDEVICE, const UINT*, D3D10DDI_HSHADER, D3D10DDI_HRTSHADER, TArgs...)>
+    template <typename TFirst, typename... TArgs>
+    struct InitializeDeferredHandle<void (APIENTRY*)(D3D10DDI_HDEVICE, const UINT*, D3D10DDI_HSHADER, D3D10DDI_HRTSHADER, TFirst, TArgs...)>
     {
-        static void Initialize(D3D10DDI_HDEVICE, const UINT*, D3D10DDI_HSHADER handle, D3D10DDI_HRTSHADER rtHandle, TArgs...)
+        static void Initialize(D3D10DDI_HDEVICE, const UINT*, D3D10DDI_HSHADER handle, D3D10DDI_HRTSHADER rtHandle, TFirst, TArgs...)
         {
             reinterpret_cast<DeviceChildDeferred<D3D10DDI_HSHADER>*>(handle.pDrvPrivate)->m_ImmediateHandle = D3D10DDI_HSHADER{ rtHandle.handle };
         }

--- a/include/VideoTranslate.hpp
+++ b/include/VideoTranslate.hpp
@@ -83,7 +83,7 @@ namespace D3D11On12
 
         static inline D3D12_VIDEO_DECODE_ARGUMENT_TYPE VideoDecodeArgumentType(D3D11_DDI_VIDEO_DECODER_BUFFER_TYPE Type11)
         {
-            static constexpr D3D12_VIDEO_DECODE_ARGUMENT_TYPE map[] =
+            static const D3D12_VIDEO_DECODE_ARGUMENT_TYPE map[] =
             {
                 (D3D12_VIDEO_DECODE_ARGUMENT_TYPE)-1,
                 D3D12_VIDEO_DECODE_ARGUMENT_TYPE_PICTURE_PARAMETERS,

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -31,7 +31,7 @@ namespace D3D11On12
         if (APISupport1 & D3D12_FORMAT_SUPPORT1_VIDEO_PROCESSOR_INPUT) *pData |= D3D11_1DDI_FORMAT_SUPPORT_VIDEO_PROCESSOR_INPUT;
         if (APISupport1 & D3D12_FORMAT_SUPPORT1_IA_VERTEX_BUFFER) *pData |= D3D11_1DDI_FORMAT_SUPPORT_VERTEX_BUFFER;
         if (APISupport1 & D3D12_FORMAT_SUPPORT1_BUFFER) *pData |= D3D11_1DDI_FORMAT_SUPPORT_BUFFER;
-        constexpr D3D12_FORMAT_SUPPORT1 D3D12_FORMAT_SUPPORT1_CAPTURE = (D3D12_FORMAT_SUPPORT1)0x80000000;
+        const D3D12_FORMAT_SUPPORT1 D3D12_FORMAT_SUPPORT1_CAPTURE = (D3D12_FORMAT_SUPPORT1)0x80000000;
         if (APISupport1 & D3D12_FORMAT_SUPPORT1_CAPTURE) *pData |= D3D11_1DDI_FORMAT_SUPPORT_CAPTURE;
         if (APISupport1 & D3D12_FORMAT_SUPPORT1_SHADER_GATHER) *pData |= D3D11_1DDI_FORMAT_SUPPORT_SHADER_GATHER;
 
@@ -355,40 +355,40 @@ namespace D3D11On12
     template <typename TDevice>
     void DeviceBase::FillContextDDIs()
     {
-        m_pDDITable->pfnVsSetShader = TDevice::SetShader<D3D12TranslationLayer::e_VS>;
-        m_pDDITable->pfnPsSetShader = TDevice::SetShader<D3D12TranslationLayer::e_PS>;
-        m_pDDITable->pfnGsSetShader = TDevice::SetShader<D3D12TranslationLayer::e_GS>;
-        m_pDDITable->pfnHsSetShader = TDevice::SetShader<D3D12TranslationLayer::e_HS>;
-        m_pDDITable->pfnDsSetShader = TDevice::SetShader<D3D12TranslationLayer::e_DS>;
-        m_pDDITable->pfnCsSetShader = TDevice::SetShader<D3D12TranslationLayer::e_CS>;
+        m_pDDITable->pfnVsSetShader = TDevice::template SetShader<D3D12TranslationLayer::e_VS>;
+        m_pDDITable->pfnPsSetShader = TDevice::template SetShader<D3D12TranslationLayer::e_PS>;
+        m_pDDITable->pfnGsSetShader = TDevice::template SetShader<D3D12TranslationLayer::e_GS>;
+        m_pDDITable->pfnHsSetShader = TDevice::template SetShader<D3D12TranslationLayer::e_HS>;
+        m_pDDITable->pfnDsSetShader = TDevice::template SetShader<D3D12TranslationLayer::e_DS>;
+        m_pDDITable->pfnCsSetShader = TDevice::template SetShader<D3D12TranslationLayer::e_CS>;
 
-        m_pDDITable->pfnVsSetShaderWithIfaces = TDevice::SetShaderWithIfaces<D3D12TranslationLayer::e_VS>;
-        m_pDDITable->pfnPsSetShaderWithIfaces = TDevice::SetShaderWithIfaces<D3D12TranslationLayer::e_PS>;
-        m_pDDITable->pfnGsSetShaderWithIfaces = TDevice::SetShaderWithIfaces<D3D12TranslationLayer::e_GS>;
-        m_pDDITable->pfnHsSetShaderWithIfaces = TDevice::SetShaderWithIfaces<D3D12TranslationLayer::e_HS>;
-        m_pDDITable->pfnDsSetShaderWithIfaces = TDevice::SetShaderWithIfaces<D3D12TranslationLayer::e_DS>;
-        m_pDDITable->pfnCsSetShaderWithIfaces = TDevice::SetShaderWithIfaces<D3D12TranslationLayer::e_CS>;
+        m_pDDITable->pfnVsSetShaderWithIfaces = TDevice::template SetShaderWithIfaces<D3D12TranslationLayer::e_VS>;
+        m_pDDITable->pfnPsSetShaderWithIfaces = TDevice::template SetShaderWithIfaces<D3D12TranslationLayer::e_PS>;
+        m_pDDITable->pfnGsSetShaderWithIfaces = TDevice::template SetShaderWithIfaces<D3D12TranslationLayer::e_GS>;
+        m_pDDITable->pfnHsSetShaderWithIfaces = TDevice::template SetShaderWithIfaces<D3D12TranslationLayer::e_HS>;
+        m_pDDITable->pfnDsSetShaderWithIfaces = TDevice::template SetShaderWithIfaces<D3D12TranslationLayer::e_DS>;
+        m_pDDITable->pfnCsSetShaderWithIfaces = TDevice::template SetShaderWithIfaces<D3D12TranslationLayer::e_CS>;
 
-        m_pDDITable->pfnVsSetShaderResources = TDevice::SetShaderResources<D3D12TranslationLayer::e_VS>;
-        m_pDDITable->pfnPsSetShaderResources = TDevice::SetShaderResources<D3D12TranslationLayer::e_PS>;
-        m_pDDITable->pfnGsSetShaderResources = TDevice::SetShaderResources<D3D12TranslationLayer::e_GS>;
-        m_pDDITable->pfnHsSetShaderResources = TDevice::SetShaderResources<D3D12TranslationLayer::e_HS>;
-        m_pDDITable->pfnDsSetShaderResources = TDevice::SetShaderResources<D3D12TranslationLayer::e_DS>;
-        m_pDDITable->pfnCsSetShaderResources = TDevice::SetShaderResources<D3D12TranslationLayer::e_CS>;
+        m_pDDITable->pfnVsSetShaderResources = TDevice::template SetShaderResources<D3D12TranslationLayer::e_VS>;
+        m_pDDITable->pfnPsSetShaderResources = TDevice::template SetShaderResources<D3D12TranslationLayer::e_PS>;
+        m_pDDITable->pfnGsSetShaderResources = TDevice::template SetShaderResources<D3D12TranslationLayer::e_GS>;
+        m_pDDITable->pfnHsSetShaderResources = TDevice::template SetShaderResources<D3D12TranslationLayer::e_HS>;
+        m_pDDITable->pfnDsSetShaderResources = TDevice::template SetShaderResources<D3D12TranslationLayer::e_DS>;
+        m_pDDITable->pfnCsSetShaderResources = TDevice::template SetShaderResources<D3D12TranslationLayer::e_CS>;
 
-        m_pDDITable->pfnVsSetConstantBuffers = TDevice::SetConstantBuffers<D3D12TranslationLayer::e_VS>;
-        m_pDDITable->pfnPsSetConstantBuffers = TDevice::SetConstantBuffers<D3D12TranslationLayer::e_PS>;
-        m_pDDITable->pfnGsSetConstantBuffers = TDevice::SetConstantBuffers<D3D12TranslationLayer::e_GS>;
-        m_pDDITable->pfnHsSetConstantBuffers = TDevice::SetConstantBuffers<D3D12TranslationLayer::e_HS>;
-        m_pDDITable->pfnDsSetConstantBuffers = TDevice::SetConstantBuffers<D3D12TranslationLayer::e_DS>;
-        m_pDDITable->pfnCsSetConstantBuffers = TDevice::SetConstantBuffers<D3D12TranslationLayer::e_CS>;
+        m_pDDITable->pfnVsSetConstantBuffers = TDevice::template SetConstantBuffers<D3D12TranslationLayer::e_VS>;
+        m_pDDITable->pfnPsSetConstantBuffers = TDevice::template SetConstantBuffers<D3D12TranslationLayer::e_PS>;
+        m_pDDITable->pfnGsSetConstantBuffers = TDevice::template SetConstantBuffers<D3D12TranslationLayer::e_GS>;
+        m_pDDITable->pfnHsSetConstantBuffers = TDevice::template SetConstantBuffers<D3D12TranslationLayer::e_HS>;
+        m_pDDITable->pfnDsSetConstantBuffers = TDevice::template SetConstantBuffers<D3D12TranslationLayer::e_DS>;
+        m_pDDITable->pfnCsSetConstantBuffers = TDevice::template SetConstantBuffers<D3D12TranslationLayer::e_CS>;
 
-        m_pDDITable->pfnVsSetSamplers = TDevice::SetSamplers<D3D12TranslationLayer::e_VS>;
-        m_pDDITable->pfnPsSetSamplers = TDevice::SetSamplers<D3D12TranslationLayer::e_PS>;
-        m_pDDITable->pfnGsSetSamplers = TDevice::SetSamplers<D3D12TranslationLayer::e_GS>;
-        m_pDDITable->pfnHsSetSamplers = TDevice::SetSamplers<D3D12TranslationLayer::e_HS>;
-        m_pDDITable->pfnDsSetSamplers = TDevice::SetSamplers<D3D12TranslationLayer::e_DS>;
-        m_pDDITable->pfnCsSetSamplers = TDevice::SetSamplers<D3D12TranslationLayer::e_CS>;
+        m_pDDITable->pfnVsSetSamplers = TDevice::template SetSamplers<D3D12TranslationLayer::e_VS>;
+        m_pDDITable->pfnPsSetSamplers = TDevice::template SetSamplers<D3D12TranslationLayer::e_PS>;
+        m_pDDITable->pfnGsSetSamplers = TDevice::template SetSamplers<D3D12TranslationLayer::e_GS>;
+        m_pDDITable->pfnHsSetSamplers = TDevice::template SetSamplers<D3D12TranslationLayer::e_HS>;
+        m_pDDITable->pfnDsSetSamplers = TDevice::template SetSamplers<D3D12TranslationLayer::e_DS>;
+        m_pDDITable->pfnCsSetSamplers = TDevice::template SetSamplers<D3D12TranslationLayer::e_CS>;
 
         m_pDDITable->pfnDraw = TDevice::Draw;
         m_pDDITable->pfnDrawAuto = TDevice::DrawAuto;


### PR DESCRIPTION
### Summary

Fix all Clang errors with 3 patterns below.

### Pattern A — `static constexpr` → `static const` on arrays whose initializers are not constant expressions (2 sites)
Error message: `error : constexpr variable 'map' must be initialized by a constant expression`

Fix: Casting an integer to an unfixed enum where the result lies outside the enum's value range (e.g. `(EnumType)-1` for an unsigned-underlying enum) is not a core constant expression. Demoting `constexpr` to `const` drops the strict constant-evaluation requirement; both arrays are only used at runtime, so nothing depended on their constexpr-ness during compile time.

### Pattern B — disambiguate `InitializeDeferredHandle<>` partial specializations (1 site)
Error message: `error: ambiguous partial specializations of 'InitializeDeferredHandle<void (*)(D3D10DDI_HDEVICE, const unsigned int *, D3D10DDI_HSHADER, D3D10DDI_HRTSHADER)>'`
    
Fix: The `TArgs...`of the updated `InitializeDeferredHandle` is allowed to be empty, in which case its signature can collapse to the 4-arg form `(HDEVICE, const UINT*, HSHADER, HRTSHADER)` — which also matches the 1st 4-arg partial specialization `InitializeDeferredHandle<void(*)(HDEVICE, TArgs, THandle, TRTHandle)>` for `PopulateDeferredShaderInit(m_pDDITable->pfnCreateComputeShader)`. Fix by adding one extra arg (`TSignature`) to exclude the 4-arg case from this specialization, and the 4-arg case is then unambiguously handled by the 1st specialization.

### Pattern C — insert `template` keyword on dependent-template-name calls (30 sites)
Error message: `error : expected expression`

Fix: In Clang, when a dependent name is followed by `<` and is intended as a template-id, it must be preceded by the `template` keyword — otherwise the compiler parses `<` as the less-than operator and reports `error: expected expression`. 

### Validation

Local build for both Clang and MSVC build pass.