### PR TITLE
CI: restore generated SLN or SLNX on VS 2026 runners

### DIFF
--- a/.github/workflows/prBuild.yml
+++ b/.github/workflows/prBuild.yml
@@ -44,7 +44,18 @@ jobs:
       run: cmake -B ${{github.workspace}}/build -DCMAKE_SYSTEM_VERSION="10.0.26100.0"
 
     - name: Nuget Restore
-      run: nuget restore ${{github.workspace}}/build/D3D11on12.sln
+      shell: pwsh
+      run: |
+        $solutions = @(
+          Get-ChildItem "${{ github.workspace }}/build" -File |
+            Where-Object { $_.Extension -in '.sln', '.slnx' }
+        )
+
+        if ($solutions.Count -ne 1) {
+          throw "Expected exactly one generated solution, found $($solutions.Count): $($solutions.FullName -join ', ')"
+        }
+
+        nuget restore $solutions[0].FullName
 
     - name: Build
       # Build your program with the given configuration


### PR DESCRIPTION
## Problem

`windows-latest` now resolves to the Windows Server 2025 / Visual Studio 2026 runner. CMake therefore selects the Visual Studio 18 2026 generator, which emits a `.slnx` solution. The workflow hard-codes a generated `.sln` path, so NuGet restore fails with `Input file does not exist` immediately after successful CMake generation.

This is independent of the open Dependabot action-update PR: a separate run using the previous `actions/checkout` and `NuGet/setup-nuget` versions fails identically.

## Fix

Discover the single generated `.sln` or `.slnx` file and restore that path. The check fails loudly if CMake generates zero or multiple solutions. Explicit `nuget.exe restore` is retained for native `packages.config` compatibility.

## Validation

- Compared the last green runner (`windows-2025`, Visual Studio 17 2022, `.sln`) with the current failure (`windows-2025-vs2026`, Visual Studio 18 2026, missing hard-coded `.sln`).
- Verified the same failure signature across D3D12TranslationLayer, D3D11On12, and D3D9On12.
- `git diff --check` passes; this PR changes only `.github/workflows/prBuild.yml`.
- GitHub Actions is the runtime validation for the generated `.slnx` path.
